### PR TITLE
Change default ports

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -4,6 +4,6 @@ upstream_server=8.8.4.4
 # args directly passed to dnsmasq executable
 dnsmasq_args=--domain-needed --bogus-priv --cache-size=1000
 # port of the local server
-server_port=5353
+server_port=9000
 # port for outgoing connections made by server
-output_port=5354
+output_port=9001


### PR DESCRIPTION
Looks like port 5353 causes issues when using MicroG. This PR changes default ports to 9000 and 9001.